### PR TITLE
Reset file input after import attempt

### DIFF
--- a/src/options/ui.js
+++ b/src/options/ui.js
@@ -162,6 +162,8 @@ const updatePreview = () => {
 const loadFromFile = async ({ currentTarget }) => {
   try {
     const { files } = currentTarget;
+    if (files.length === 0) return;
+
     const [importedPalettes] = files;
 
     if (importedPalettes.type !== 'application/json') {
@@ -187,6 +189,8 @@ const loadFromFile = async ({ currentTarget }) => {
   } catch (exception) {
     window.alert(exception.toString());
     currentTarget.value = currentTarget.defaultValue;
+  } finally {
+    currentTarget.value = '';
   }
 };
 

--- a/src/options/ui.js
+++ b/src/options/ui.js
@@ -188,9 +188,8 @@ const loadFromFile = async ({ currentTarget }) => {
     window.alert(`Successfully imported ${validPaletteEntries.length} palettes!`);
   } catch (exception) {
     window.alert(exception.toString());
-    currentTarget.value = currentTarget.defaultValue;
   } finally {
-    currentTarget.value = '';
+    currentTarget.value = currentTarget.defaultValue;
   }
 };
 


### PR DESCRIPTION
### User-facing changes
-  Triggering the file input twice in a row with the same file results in a UI update.

### Technical explanation
As far as I can tell, setting the value attribute on an `<input type="file">` should clear it (setting the files attribute looked like it needed a roundabout way of generating an empty `FileList` to set it to).

### Issues this closes
resolves #88