### PR TITLE
Update Snow Bright palette name

### DIFF
--- a/src/paletteData.json
+++ b/src/paletteData.json
@@ -143,7 +143,7 @@
     "secondary-accent": "64, 24, 15",
     "follow": "21, 36, 23"
   },
-  "nuclearWhite": {
+  "snowBright": {
     "black": "0, 0, 0",
     "white": "255, 255, 255",
     "white-on-dark": "0, 0, 0",

--- a/src/paletteData.json
+++ b/src/paletteData.json
@@ -143,7 +143,7 @@
     "secondary-accent": "64, 24, 15",
     "follow": "21, 36, 23"
   },
-  "snowBright": {
+  "nuclearWhite": {
     "black": "0, 0, 0",
     "white": "255, 255, 255",
     "white-on-dark": "0, 0, 0",

--- a/src/palettes.json
+++ b/src/palettes.json
@@ -10,7 +10,7 @@
       ["ghost", "Ghost"],
       ["vampire", "Vampire"],
       ["pumpkin", "Pumpkin"],
-      ["snowBright", "Snow Bright"],
+      ["nuclearWhite", "Snow Bright"],
       ["gothRave", "Goth Rave"],
       ["pride", "Pride"]
     ]

--- a/src/palettes.json
+++ b/src/palettes.json
@@ -10,7 +10,7 @@
       ["ghost", "Ghost"],
       ["vampire", "Vampire"],
       ["pumpkin", "Pumpkin"],
-      ["nuclearWhite", "Nuclear White"],
+      ["snowBright", "Snow Bright"],
       ["gothRave", "Goth Rave"],
       ["pride", "Pride"]
     ]


### PR DESCRIPTION
### User-facing changes
- Updates the name of the "Snow Bright" palette in accordance with Tumblr's rename.

### Technical explanation
n/a

### Issues this closes
resolves #102