### PR TITLE
Remove outdated palette button hiding code

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,34 +1,3 @@
-const delayToDocumentIdle = delayedFunction => {
-  document.readyState === 'complete'
-    ? delayedFunction()
-    : window.addEventListener('load', delayedFunction);
-};
-
-const hideChangePaletteButton = function () {
-  if (document.getElementById('palette-override') !== null) {
-    return;
-  }
-
-  if ([...document.scripts].some(({ src }) => src.includes('/pop/')) === false) {
-    return;
-  }
-
-  const toRunInPageContext = function () {
-    const changePaletteLabel = window.tumblr.languageData.translations['Change Palette'] || 'Change Palette';
-    const textContent = `button[aria-label="${changePaletteLabel}"] { display: none !important; }`;
-    const style = Object.assign(document.createElement('style'), { textContent, id: 'palette-override' });
-    document.head.append(style);
-  };
-
-  const scriptWithNonce = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
-  const nonce = scriptWithNonce.nonce || scriptWithNonce.getAttribute('nonce');
-
-  const injectable = `(${toRunInPageContext.toString()})()`;
-  const script = Object.assign(document.createElement('script'), { nonce, textContent: injectable });
-  document.documentElement.append(script);
-  script.remove();
-};
-
 const showChangePaletteButton = function () {
   const style = document.getElementById('palette-override');
   if (style) style.remove();
@@ -49,8 +18,6 @@ const applyCurrentPalette = async function () {
     appliedPaletteEntries = [];
     return;
   }
-
-  delayToDocumentIdle(hideChangePaletteButton);
 
   const paletteIsBuiltIn = currentPalette.startsWith('palette:') === false;
   const { [currentPalette]: currentPaletteData = {} } = paletteIsBuiltIn


### PR DESCRIPTION
### User-facing changes
- None, mostly.

### Technical explanation

The code in question, used to hide the nonfunctional-with-this-extension "change palette" button in the UI:
- Doesn't work, as the capitalization of its selector is wrong (at some point I guess it changed to `Change palette`)
- Isn't needed, as this button doesn't exist in the current version of the UI. I don't know of any currently updated scripts that revert the UI in a way that brings back the code path that produces the button in question, either, though the code remains.
- Logs an error in the dashboard occasionally (I did not look into reproducing this reliably, due to the previous bullet points).

Therefore, this removes it.

### Issues this closes
n/a