### PR TITLE
Fix accent colors not applying

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,8 @@ const applyCurrentPalette = async function () {
     ? await paletteData
     : await browser.storage.local.get(currentPalette);
 
+  currentPaletteData['deprecated-accent'] = currentPaletteData.accent;
+
   const currentPaletteKeys = Object.keys(currentPaletteData);
   const currentPaletteEntries = Object.entries(currentPaletteData);
 

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,7 @@ const applyCurrentPalette = async function () {
     : await browser.storage.local.get(currentPalette);
 
   currentPaletteData['deprecated-accent'] = currentPaletteData.accent;
+  delete currentPaletteData.accent;
 
   const currentPaletteKeys = Object.keys(currentPaletteData);
   const currentPaletteEntries = Object.entries(currentPaletteData);


### PR DESCRIPTION
### User-facing changes

Fixes accent colors not being affected by the extension due to a Tumblr code change that I didn't really look into.

### Technical explanation

Applies what used to be an `accent` override to the `deprecated-accent` CSS variable as well; this results in no changes being needed to custom palettes as well as built-in palette data.

I assume the change to this variable name could be a sign of more things to come that could be problematic for custom palettes still working without tweaks/migration? But if so, that can be a problem for later.

### Issues this closes

Resolves #183, resolves #182