### PR TITLE
Fix accent colors when applying a palette multiple times

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -20,11 +20,14 @@ const applyCurrentPalette = async function () {
   }
 
   const paletteIsBuiltIn = currentPalette.startsWith('palette:') === false;
-  const { [currentPalette]: currentPaletteData = {} } = paletteIsBuiltIn
+  const { [currentPalette]: rawCurrentPaletteData = {} } = paletteIsBuiltIn
     ? await paletteData
     : await browser.storage.local.get(currentPalette);
 
-  currentPaletteData['deprecated-accent'] = currentPaletteData.accent;
+  const currentPaletteData = {
+    ...rawCurrentPaletteData,
+    'deprecated-accent': rawCurrentPaletteData.accent
+  };
   delete currentPaletteData.accent;
 
   const currentPaletteKeys = Object.keys(currentPaletteData);


### PR DESCRIPTION
### Description

The mutation applied to (what I hadn't realized was) a persistently referenced palette data object would cause the `deprecated-accent` property to be overwritten with `undefined` when a palette was applied multiple times to the same webpage; this fixes this.

Resolves #201.

### Testing steps

- Navigate to, for example, https://www.tumblr.com/dashboard/blog_subs
- Apply a built-in palette
- Apply no palette
- Apply the same built-in palette

Without this PR, the "The latest posts from your favorite blogs that you're subscribed to!" element's background will vanish; with this PR it should not.