### PR TITLE
Implement automatic light/dark mode palettes

### DIFF
--- a/src/browser_action/popup.css
+++ b/src/browser_action/popup.css
@@ -121,6 +121,10 @@ a {
   color: rgb(var(--accent));
 }
 
-select:not([data-value="custom"]) ~ :is([for="font-family-custom"], [id="font-family-custom"]) {
+#font-family:not([data-value="custom"]) ~ :is([for="font-family-custom"], [id="font-family-custom"]) {
+  display: none;
+}
+
+#palette:not([data-value="prefers-color-scheme"]) ~ :is([for="palette-light"], [id="palette-light"], [for="palette-dark"], [id="palette-dark"]) {
   display: none;
 }

--- a/src/browser_action/popup.html
+++ b/src/browser_action/popup.html
@@ -16,6 +16,14 @@
         <select id="palette">
           <option value="">Default</option>
         </select>
+        <label for="palette-light"><h5>Light Mode Palette</h4></label>
+        <select id="palette-light">
+          <option value="">Default</option>
+        </select>
+        <label for="palette-dark"><h5>Dark Mode Palette</h4></label>
+        <select id="palette-dark">
+          <option value="">Default</option>
+        </select>
       </div>
       <div>
         <label for="font-family"><h4>Change Font</h4></label>

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,17 @@ const removeCssVariable = ([property]) => document.documentElement.style.removeP
 let appliedPaletteEntries = [];
 
 const applyCurrentPalette = async function () {
-  const { currentPalette = '' } = await browser.storage.local.get('currentPalette');
+  let {
+    currentPalette = '',
+    currentLightPalette = '',
+    currentDarkPalette = ''
+  } = await browser.storage.local.get(['currentPalette', 'currentLightPalette', 'currentDarkPalette']);
+
+  if (currentPalette === 'prefers-color-scheme') {
+    // todo: implement dark mode
+    console.log({ currentLightPalette, currentDarkPalette });
+    currentPalette = currentLightPalette;
+  }
 
   if (!currentPalette) {
     showChangePaletteButton();
@@ -61,9 +71,9 @@ const onStorageChanged = async function (changes, areaName) {
     return;
   }
 
-  const { currentPalette, fontFamily, customFontFamily, fontSize } = changes;
+  const { currentPalette, currentLightPalette, currentDarkPalette, fontFamily, customFontFamily, fontSize } = changes;
 
-  if (currentPalette || Object.keys(changes).some(key => key.startsWith('palette:'))) {
+  if (currentPalette || currentLightPalette || currentDarkPalette || Object.keys(changes).some(key => key.startsWith('palette:'))) {
     applyCurrentPalette();
   }
 


### PR DESCRIPTION
Currently only contains selection UI.

(I haven't bothered to look into the details of how to use media queries in the styles we're injecting at `document_start`, if that's possible. Would be nice for `@supports` in #206 though!)