### PR TITLE
Finish removing outdated palette button hiding code

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,3 @@
-const showChangePaletteButton = function () {
-  const style = document.getElementById('palette-override');
-  if (style) style.remove();
-};
-
 const paletteData = fetch(browser.runtime.getURL('/paletteData.json')).then(response => response.json());
 const setCssVariable = ([property, value]) => document.documentElement.style.setProperty(`--${property}`, value);
 const removeCssVariable = ([property]) => document.documentElement.style.removeProperty(`--${property}`);
@@ -13,7 +8,6 @@ const applyCurrentPalette = async function () {
   const { currentPalette = '' } = await browser.storage.local.get('currentPalette');
 
   if (!currentPalette) {
-    showChangePaletteButton();
     appliedPaletteEntries.forEach(removeCssVariable);
     appliedPaletteEntries = [];
     return;


### PR DESCRIPTION
### User-facing changes
none

### Technical explanation
Removes some unused code that I, puzzlingly, forgot to remove in #178.

Let's just say I did it in two releases so that the Firefox automatic update process would... yeah, no, I've got nothing.


