### PR TITLE
Implement live editor preview

### DIFF
--- a/src/options/ui.css
+++ b/src/options/ui.css
@@ -307,6 +307,10 @@ input[type="text"]:disabled {
   opacity: 1;
 }
 
+#preview > label {
+  text-align: center;
+}
+
 #transfer details[open] summary {
   margin-bottom: 1ch;
 }

--- a/src/options/ui.html
+++ b/src/options/ui.html
@@ -64,6 +64,10 @@
               </div>
             </div>
           </div>
+          <label>
+            <input id="live-preview-toggle" type="checkbox">
+            Preview on Tumblr
+          </label>
         </section>
         <section id="transfer">
           <h1>Transfer palettes</h1>

--- a/src/options/ui.js
+++ b/src/options/ui.js
@@ -19,6 +19,7 @@ const saveButton = document.getElementById('save');
 const deleteButton = document.getElementById('delete');
 
 const previewSection = document.getElementById('preview');
+const livePreviewToggle = document.getElementById('live-preview-toggle');
 
 const paletteForm = document.getElementById('palette-form');
 const createdTime = paletteForm.querySelector('time');
@@ -149,7 +150,21 @@ const updatePreview = () => {
   formEntries
     .filter(([property, value]) => value.startsWith('#'))
     .forEach(([property, value]) => previewSection.style.setProperty(`--${property}`, value));
+
+  if (livePreviewToggle.checked) {
+    const storageValue = Object.fromEntries(
+      formEntries
+        .filter(([property, value]) => value.startsWith('#'))
+        .map(([key, value]) => [key, hexToRgb(value)])
+    );
+    browser.storage.local.set({ previewPalette: storageValue, previewLastActive: Date.now() });
+  } else {
+    browser.storage.local.remove('previewPalette');
+  }
 };
+
+livePreviewToggle.addEventListener('change', () => setTimeout(updatePreview, 200));
+setInterval(() => livePreviewToggle.checked && browser.storage.local.set({ previewLastActive: Date.now() }), 100);
 
 newSelect.addEventListener('change', createNewPalette);
 openSelect.addEventListener('change', onPaletteSelected);
@@ -168,5 +183,7 @@ paletteForm.addEventListener('submit', onFormSubmitted);
 paletteForm.addEventListener('input', updatePreview);
 paletteForm.reset();
 
-browser.storage.onChanged.addListener(renderPalettes);
+browser.storage.onChanged.addListener(
+  (changes) => Object.keys(changes).some((key) => key.startsWith('palette:')) && renderPalettes()
+);
 renderPalettes();


### PR DESCRIPTION
### User-facing changes
Adds a checkbox to the manage palettes page that, when checked, makes the colors you're currently adjusting update live in all of your Tumblr tabs in real time. This is, IMO, awesome for palette creation. 

### Technical explanation
See comments.

### Issues this closes
I never bothered to make an issue to request this, apparently.