### PR TITLE
README: Update ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Palettes for Tumblr [![CI](https://github.com/AprilSylph/Palettes-for-Tumblr/workflows/CI/badge.svg)](https://github.com/AprilSylph/Palettes-for-Tumblr/actions?query=workflow%3ACI)
+# Palettes for Tumblr [![CI](https://github.com/AprilSylph/Palettes-for-Tumblr/actions/workflows/ci.yml/badge.svg)](https://github.com/AprilSylph/Palettes-for-Tumblr/actions/workflows/ci.yml)
 A colour scheme manager for Tumblr!
 
 ## Features


### PR DESCRIPTION
Currently the CI badge in the readme displays as failing ~~because it refers to the most recent CI run on any branch, rather than specifically referring to the main branch.~~

This updates the markdown with the result of clicking "create status badge" on https://github.com/AprilSylph/Palettes-for-Tumblr/actions/workflows/ci.yml, which is—I assume?—the intended status report.

~~I'm not actually sure where the documentation for the url in the current markdown is; it would not be a common scenario, but I could imagine some developer actually wanting a "last run on any branch status" badge and the [current docs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge) don't mention that.~~

Edit: Or... maybe the current URL is just old and stuck on "failing." No idea.