### PR TITLE
Fix palette system update script in GDPR countries

### DIFF
--- a/dev/update-palette-system-data.js
+++ b/dev/update-palette-system-data.js
@@ -8,6 +8,14 @@ try {
 
   await page.waitForSelector(':root:not(:has([data-rh]))');
 
+  await Promise.all(
+    page.frames().map(async (frame) => {
+      const privacyAgreeButton = await frame.$('.cmp__dialog-footer button.cmp-components-button.white-space-normal.is-primary');
+      privacyAgreeButton?.click();
+    })
+  );
+  await page.waitForSelector(':root:not(:has(#cmp-app-container iframe))');
+
   const allData = {};
 
   for (let i = 0; i < 12; i++) {


### PR DESCRIPTION
### Description

This fixes an issue where the script added in #216 to automatically update the built-in Tumblr palette system variables would fail because of the "Tumblr Privacy & Cookies" GDPR popup.

### Testing steps
- be in a GDPR country or buy a VPN and pretend you are
- confirm that `npm run update-palette-system-data` dismisses the GDPR consent popup and works

