### PR TITLE
Verify native palette data in update script

### DIFF
--- a/dev/update-palette-system-data.js
+++ b/dev/update-palette-system-data.js
@@ -2,6 +2,12 @@ import puppeteer from 'puppeteer';
 import fs from 'node:fs/promises';
 
 try {
+  // const currentPaletteData = await fs.readFile('src/paletteData.json', 'utf8')
+  //   .then((text) => JSON.parse(text))
+  //   .catch(() => ({}));
+  const currentPaletteData = {};
+  let currentPaletteChanged = false;
+
   const browser = await puppeteer.launch({ browser: 'firefox', headless: false });
   const page = await browser.newPage();
   await page.goto('https://www.tumblr.com/');
@@ -20,17 +26,31 @@ try {
     if (key === 'snowBright') key = 'nuclearWhite';
 
     const styleElement = await page.waitForSelector('#root style');
-    const data = await styleElement.evaluate((el) => {
+    const { primaryData, systemData } = await styleElement.evaluate((el) => {
       const rootRuleStyle = [...el.sheet.cssRules].find((rule) => rule.selectorText === ':root').style;
 
       const keys = [...rootRuleStyle];
-      const entries = keys
-        .map((key) => [key, rootRuleStyle.getPropertyValue(key)])
-        .filter(([key, value]) => key.startsWith('--') && /rgba\(\d/.test(value));
-      return Object.fromEntries(entries.map(([key, value]) => [key.replace(/^--/, ''), value]));
+      const entries = keys.map((key) => [key, rootRuleStyle.getPropertyValue(key)]);
+
+      const primaryEntries = entries.filter(([key, value]) => key.startsWith('--') && /^\d+, \d+, \d+/.test(value));
+      const primaryData = Object.fromEntries(primaryEntries.map(([key, value]) => [key.replace(/^--/, ''), value]));
+
+      const systemEntries = entries.filter(([key, value]) => key.startsWith('--') && /rgba\(\d/.test(value));
+      const systemData = Object.fromEntries(systemEntries.map(([key, value]) => [key.replace(/^--/, ''), value]));
+
+      return { primaryData, systemData };
     });
 
-    allData[key] = data;
+    currentPaletteData[key] ??= {};
+    for (const [colorUnmodified, rgb] of Object.entries(primaryData)) {
+      const color = colorUnmodified === 'deprecated-accent' ? 'accent' : colorUnmodified;
+      if (currentPaletteData[key][color] !== rgb) {
+        currentPaletteChanged = true;
+        currentPaletteData[key][color] = rgb;
+      }
+    }
+
+    allData[key] = systemData;
 
     await page.keyboard.down('Shift');
     await page.keyboard.press('KeyP');
@@ -43,6 +63,13 @@ try {
     encoding: 'utf8',
     flag: 'w+'
   });
+
+  if (currentPaletteChanged) {
+    await fs.writeFile('src/paletteData.json', JSON.stringify(currentPaletteData, null, 2), {
+      encoding: 'utf8',
+      flag: 'w+'
+    });
+  }
 
   console.log(`wrote data for ${Object.keys(allData).length} palettes`);
 } catch (e) {


### PR DESCRIPTION
This was the result of an attempt to have the automated script that writes the palette system data for the native palettes write directly into `paletteData.json` as well.

A surprisingly-seemingly-unsolvable problem is that node appears to throw away property order when parsing JSON, preventing one from reading a JSON file and writing it back without intrinsically sorting the properties and thus making a big diff, and I didn't find an alternative JSON parse library that helps with this.

Oh well. I started doing this at all because I noticed that one of the native properties looked wrong, which hopefully should only happen once, so this is more of a oneshot thing anyway.