### PR TITLE
Override `font-family-modern` font weight (link elements method)

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -39,7 +39,7 @@
   },
   "permissions": [ "storage" ],
   "web_accessible_resources": [{
-    "resources": [ "*.json" ],
+    "resources": [ "*.json", "*.js" ],
     "matches": [ "*://www.tumblr.com/*" ]
   }],
 

--- a/src/override_font_weight.js
+++ b/src/override_font_weight.js
@@ -35,7 +35,6 @@
 
     const allCssStyleRules = sheets
       .flatMap((sheet) => [...sheet.cssRules])
-      .flatMap((rule) => (rule instanceof CSSMediaRule ? [...rule.cssRules] : [rule]))
       .filter((rule) => rule instanceof CSSStyleRule && rule.style)
       .map(({ selectorText, style }) => ({
         selectorText,

--- a/src/override_font_weight.js
+++ b/src/override_font_weight.js
@@ -1,0 +1,63 @@
+{
+  const styleElement = Object.assign(document.createElement('style'), {
+    id: 'palettes-for-tumblr-override'
+  });
+  document.getElementById('palettes-for-tumblr-override')?.remove();
+  document.documentElement.append(styleElement);
+
+  const processedUrls = new Set();
+  const selectors = new Set();
+
+  const processLinkElements = async () => {
+    const linkElements = [...document.head.querySelectorAll('link[rel="stylesheet"][href^="https://assets.tumblr.com/pop/"]')]
+      .filter(element => !processedUrls.has(element.href));
+    linkElements.forEach(element => processedUrls.add(element.href));
+
+    const temporaryElements = [];
+    const crossOriginLinkElements = linkElements.map((element) => {
+      if (['', 'anonymous', 'use-credentials'].includes(element.crossOrigin)) return element;
+
+      const crossOriginElement = Object.assign(document.createElement('link'), {
+        rel: 'stylesheet',
+        href: element.href,
+        crossOrigin: 'anonymous'
+      });
+      temporaryElements.push(crossOriginElement);
+      document.head.append(crossOriginElement);
+      return crossOriginElement;
+    });
+
+    const sheets = await Promise.all(crossOriginLinkElements.map(async (element) => {
+      if (!element.sheet) await new Promise((resolve) => element.addEventListener('load', resolve));
+      return element.sheet;
+    }));
+    temporaryElements.forEach(element => element.remove());
+
+    const allCssStyleRules = sheets
+      .flatMap((sheet) => [...sheet.cssRules])
+      .flatMap((rule) => (rule instanceof CSSMediaRule ? [...rule.cssRules] : [rule]))
+      .filter((rule) => rule instanceof CSSStyleRule && rule.style)
+      .map(({ selectorText, style }) => ({
+        selectorText,
+        rules: Object.fromEntries([...style].map((key) => [key, style.getPropertyValue(key)]))
+      }));
+
+    allCssStyleRules
+      .filter(
+        ({ selectorText, rules }) =>
+          !selectors.has(selectorText) &&
+          rules['font-family'] === 'var(--font-family-modern)' &&
+          rules['font-weight'] === '350'
+      )
+      .forEach(({ selectorText }) => selectors.add(selectorText));
+
+    styleElement.textContent = `
+      body.override-font-weight :is(${[...selectors].join(', ')}) {
+        font-weight: normal;
+      }
+    `;
+  };
+
+  processLinkElements();
+  new MutationObserver(processLinkElements).observe(document.head, { childList: true });
+}


### PR DESCRIPTION
Phew boy. That was a lot more CORS research and general shenanigans than I anticipated.

- [x] investigate alternative `new CSSStyleSheet().replace(await fetch(url).then(response => response.text()).then(` method

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

tbd

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

tbd