### PR TITLE
Override `font-family-modern` font weight (fetch method) 

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -52,6 +52,10 @@ const applyFontFamily = async function () {
     '--font-family-modern',
     fontFamily === 'custom' ? customFontFamily : fontFamily
   );
+  const { fontWeightOverride } = await import(browser.runtime.getURL('/override_font_weight.js'));
+  document.getElementById('palettes-for-tumblr-override')?.remove();
+  (fontFamily === 'custom' ? customFontFamily : fontFamily) &&
+    document.documentElement.append(fontWeightOverride);
 };
 
 const applyFontSize = async function () {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -39,7 +39,7 @@
   },
   "permissions": [ "storage" ],
   "web_accessible_resources": [{
-    "resources": [ "*.json" ],
+    "resources": [ "*.json", "*.js" ],
     "matches": [ "*://www.tumblr.com/*" ]
   }],
 

--- a/src/override_font_weight.js
+++ b/src/override_font_weight.js
@@ -12,18 +12,12 @@ const getSelectorsFromUrl = async (url) => {
   const cssText = await fetch(url).then(response => response.text());
   const sheet = await new CSSStyleSheet().replace(cssText);
 
-  const allCssStyleRules = [...sheet.cssRules]
+  return [...sheet.cssRules]
     .filter((rule) => rule instanceof CSSStyleRule && rule.style)
-    .map(({ selectorText, style }) => ({
-      selectorText,
-      rules: Object.fromEntries([...style].map((key) => [key, style.getPropertyValue(key)]))
-    }));
-
-  return allCssStyleRules
     .filter(
-      ({ rules }) =>
-        rules['font-family'] === 'var(--font-family-modern)' &&
-        rules['font-weight'] === '350'
+      ({ style }) =>
+        style.getPropertyValue('font-family') === 'var(--font-family-modern)' &&
+        style.getPropertyValue('font-weight') === '350'
     )
     .map(({ selectorText }) => selectorText);
 };

--- a/src/override_font_weight.js
+++ b/src/override_font_weight.js
@@ -1,0 +1,49 @@
+await new Promise((resolve) =>
+  document.readyState === 'loading'
+    ? document.addEventListener('readystatechange', resolve, { once: true })
+    : resolve()
+);
+
+export const fontWeightOverride = Object.assign(document.createElement('style'), {
+  id: 'palettes-for-tumblr-override'
+});
+
+const getSelectorsFromUrl = async (url) => {
+  const cssText = await fetch(url).then(response => response.text());
+  const sheet = await new CSSStyleSheet().replace(cssText);
+
+  const allCssStyleRules = [...sheet.cssRules]
+    .filter((rule) => rule instanceof CSSStyleRule && rule.style)
+    .map(({ selectorText, style }) => ({
+      selectorText,
+      rules: Object.fromEntries([...style].map((key) => [key, style.getPropertyValue(key)]))
+    }));
+
+  return allCssStyleRules
+    .filter(
+      ({ rules }) =>
+        rules['font-family'] === 'var(--font-family-modern)' &&
+        rules['font-weight'] === '350'
+    )
+    .map(({ selectorText }) => selectorText);
+};
+
+const cache = {};
+
+const processLinkElements = async () => {
+  [...document.head.querySelectorAll('link[rel="stylesheet"][href^="https://assets.tumblr.com/pop/"]')]
+    .map(element => element.href)
+    .forEach(url => {
+      cache[url] ??= getSelectorsFromUrl(url);
+    });
+
+  const selectors = await Promise.all(Object.values(cache)).then(results => results.flat());
+  fontWeightOverride.textContent = `
+    ${selectors.join(', ')} {
+      font-weight: normal;
+    }
+  `;
+};
+
+processLinkElements();
+new MutationObserver(processLinkElements).observe(document.head, { childList: true });

--- a/src/override_font_weight.js
+++ b/src/override_font_weight.js
@@ -31,7 +31,7 @@ const processLinkElements = async () => {
       cache[url] ??= getSelectorsFromUrl(url);
     });
 
-  const selectors = await Promise.all(Object.values(cache)).then(results => results.flat());
+  const selectors = await Promise.all(Object.values(cache)).then(results => [...new Set(results.flat())]);
   fontWeightOverride.textContent = `
     ${selectors.join(', ')} {
       font-weight: normal;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As in #231, this overrides the unusual 350 font weight used by Tumblr on elements with the `--font-family-modern` font face when we're changing what font that variable refers to, preventing overly thin font rendering in certain scenarios. This, however, creates the selectors live in real time.

This is done with a module that exports a style element which it will update to include the selectors from any Tumblr stylesheets in the document head that set `font-family: var(--font-family-modern)` and `font-weight: 350`. A mutation observer is used to detect the addition of new link elements, like when opening the post editor or navigating to communities, and their target css files are fetched and parsed to find matching rules using the (clunky, imo) browser native CSSOM API.

Resolves #223.

Obsoletes #232, which solved the problem in a broadly similar way but tried to read the `sheet` property of the link elements themselves. That ran into CORS issues, requiring the creation of some otherwise-duplicate link elements with `crossorigin=anonymous` and required the script to be injected into the page context (only in Firefox, I would guess, but I didn't test chromium). It also conferred no real efficiency benefit because the direct fetch used in this PR hits the service worker cache anyway, so it's free.

Note that this intentionally doesn't include rules which are inside a media query, of which there are two (both making changes exclusive to the mobile layout, neither of which I could actually observe). If needed, we could definitely add this functionality (https://github.com/marcustyphoon/Palettes-for-Tumblr/commit/2f586b9f801ce15fb4613dcb4e8c6ece662ffc8c translated to CSSOM).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Load the extension without this PR and set the font override to Helvetica Neue. Observe unusually thin text in the search box, on activity items, and on the communities settings page. (I observed this on MacOS in Firefox with Helvetica Neue, American Typewriter, and Gill Sans.)
- Load the extension with this PR and set the font override to Helvetica Neue. Confirm that text is no longer thin.
- Set the font override to "default." Confirm that no change is made to the Favorit Modern font weight.
- Set the font override to "custom" and don't type anything in the box. Confirm that no change is made to the Favorit Modern font weight.
- Load the extension in Firefox with this PR and set the font override to Helvetica Neue. Confirm that changes to the stylesheet (e.g. `font-weight: bold`) are instantly applied to the page (when the file is saved if using `web-ext run`, or when the extension is reloaded from another tab). This is a proxy for Firefox autoupdate testing; see https://github.com/AprilSylph/XKit-Rewritten/pull/1619.