### PR TITLE
chore: Update Goth Rave Tumblr palette

### DIFF
--- a/src/paletteSystemData.json
+++ b/src/paletteSystemData.json
@@ -1766,7 +1766,7 @@
     "content-mobile-container": "rgba(13, 13, 13, 1)",
     "content-fg": "rgba(176, 157, 255, 1)",
     "content-fg-secondary": "rgba(150, 125, 255, 1)",
-    "content-fg-tertiary": "rgba(124, 92, 255, 1)",
+    "content-fg-tertiary": "rgba(99, 74, 204, 1)",
     "color-panel-border": "rgba(0, 0, 0, 1)",
     "color-tint": "rgba(0, 0, 0, 0.1)",
     "color-tint-strong": "rgba(0, 0, 0, 0.15)",


### PR DESCRIPTION
This updates the native Tumblr colors by running the update-palette-system-data script. (Glad I made that thing, I guess.)

It makes the purple of the character count of the note box in the moderation modal for a post in a community you're an admin of and the "no activity" text in the moderation queue a bit less bright, which definitely looks more correct. No, that wasn't worth the time to find, but I was curious, and I have collected [some experience](https://github.com/user-attachments/assets/ecb85992-9e71-475a-94c1-d5bd17db1b79) doing this at this point.
