### PR TITLE
Custom palette dev: Generate static tokens

### DIFF
--- a/src/dev/dom.js
+++ b/src/dev/dom.js
@@ -1,0 +1,20 @@
+/**
+ * Create elements with simple syntax
+ * @param {string} tagName - Type of element to create
+ * @param {object} [attributes] - Property-value pairs to set as HTML/XML attributes (e.g. { href: '/' })
+ * @param {object} [events] - Property-value pairs to set as event listeners (e.g. { click: () => {} })
+ * @param {(Node|string)[]} [children] - Zero or more valid children
+ * @returns {Element} Element created to specification
+ */
+export function dom (tagName, attributes = {}, events = {}, children = []) {
+  const element = attributes?.xmlns
+    ? document.createElementNS(attributes.xmlns, tagName)
+    : document.createElement(tagName);
+
+  attributes && Object.entries(attributes).forEach(([name, value]) => element.setAttribute(name, value));
+  events && Object.entries(events).forEach(([type, listener]) => element.addEventListener(type, listener));
+  children && element.replaceChildren(...children);
+
+  element.normalize();
+  return element;
+}

--- a/src/dev/swatches.css
+++ b/src/dev/swatches.css
@@ -1,3 +1,7 @@
+html, body {
+  overscroll-behavior: none;
+}
+
 #root {
   width: 100%;
   box-sizing: border-box;

--- a/src/dev/swatches.css
+++ b/src/dev/swatches.css
@@ -33,10 +33,13 @@
 }
 
 .swatch {
-  color: black;
   padding: 0.5em 0;
   width: 13em;
   text-align: center;
+
+  color: black;
+
+  --error: repeating-linear-gradient(45deg, rgb(255 0 0 / 0.5), rgb(255 0 0 / 0.5) 2px, transparent 4px, transparent 20px);
 }
 
 .swatch.header {

--- a/src/dev/swatches.css
+++ b/src/dev/swatches.css
@@ -1,0 +1,47 @@
+#root {
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 1em;
+}
+
+#background {
+  width: 100vw;
+  height: 100vh;
+  z-index: -1;
+  position: fixed;
+
+  --light-tile: rgb(138, 138, 138);
+  --dark-tile: rgb(128, 128, 128);
+  background: conic-gradient(
+    var(--light-tile) 90deg,
+    var(--dark-tile) 90deg 180deg,
+    var(--light-tile) 180deg 270deg,
+    var(--dark-tile) 270deg
+  );
+  background-repeat: repeat;
+  background-size: 60px 60px;
+  background-position: top left;
+}
+
+#container {
+  display: flex;
+}
+
+.columns {
+  display: flex;
+  padding: 1em;
+}
+
+.swatch {
+  color: black;
+  padding: 0.5em 0;
+  width: 13em;
+  text-align: center;
+}
+
+.swatch.header {
+  position: sticky;
+  top: 0;
+
+  background-color: darkgray;
+}

--- a/src/dev/swatches.html
+++ b/src/dev/swatches.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dev | Palettes for Tumblr</title>
+    <link rel="icon" href="/icons/16.png">
+    <link rel="stylesheet" href="/lib/normalize.min.css">
+    <link rel="stylesheet" href="/options/ui.css">
+    <link rel="stylesheet" href="swatches.css">
+    <script src="/lib/browser-polyfill.min.js"></script>
+    <script type="module" src="swatches.js"></script>
+  </head>
+  <body>
+    <div id="root">
+      <div id="background"></div>
+      <div id="container"></div>
+    </div>
+  </body>
+</html>

--- a/src/dev/swatches.js
+++ b/src/dev/swatches.js
@@ -25,13 +25,13 @@ for (const [id, label] of paletteIds) {
   nativeColumn.append(
     dom('div', { class: 'swatch header' }, null, [`${label} (real)`]),
     ...paletteKeys.map((key) =>
-      dom('div', { class: 'swatch', style: `background: var(--${key}, repeating-linear-gradient(45deg, rgb(255 0 0 / 0.5), rgb(255 0 0 / 0.5) 2px, transparent 4px, transparent 20px))` }, null, [key])
+      dom('div', { class: 'swatch', style: `background: var(--${key}, var(--error))` }, null, [key])
     )
   );
   previewColumn.append(
     dom('div', { class: 'swatch header' }, null, [label]),
     ...paletteKeys.map((key) =>
-      dom('div', { class: 'swatch', style: `background: var(--${key}, repeating-linear-gradient(45deg, rgb(255 0 0 / 0.5), rgb(255 0 0 / 0.5) 2px, transparent 4px, transparent 20px))` }, null, [key])
+      dom('div', { class: 'swatch', style: `background: var(--${key}, var(--error))` }, null, [key])
     )
   );
 

--- a/src/dev/swatches.js
+++ b/src/dev/swatches.js
@@ -47,17 +47,19 @@ for (const [id, label] of paletteIds) {
 
   Object.entries({ ...currentPaletteData, ...currentPaletteSystemData }).forEach(
     ([property, value]) =>
+      value &&
       nativeColumn.style.setProperty(
         `--${property}`,
-        !value || value.startsWith('rgb') ? value : `rgba(${value})`
+        value.startsWith('rgb') ? value : `rgba(${value})`
       )
   );
 
   Object.entries({ ...currentPaletteData, ...getSemanticTokens(currentPaletteData) }).forEach(
     ([property, value]) =>
+      value &&
       previewColumn.style.setProperty(
         `--${property}`,
-        !value || value.startsWith('rgb') ? value : `rgba(${value})`
+        value.startsWith('rgb') ? value : `rgba(${value})`
       )
   );
 

--- a/src/dev/swatches.js
+++ b/src/dev/swatches.js
@@ -1,0 +1,65 @@
+import { getSemanticTokens } from '../get_semantic_tokens.js';
+import { dom } from './dom.js';
+
+const jsonFetch = (url) => fetch(browser.runtime.getURL(url)).then((response) => response.json());
+
+const builtInPaletteList = await jsonFetch('/palettes.json');
+const builtInPalettes = await jsonFetch('/palette_data.json');
+const builtInPaletteSystem = await jsonFetch('/palette_system_data.json');
+
+const containerElement = document.getElementById('container');
+
+const paletteIds = builtInPaletteList.flatMap(([label, options]) => options);
+
+const paletteKeys = [
+  ...Object.keys(builtInPalettes.trueBlue).map((key) =>
+    key === 'accent' ? 'deprecated-accent' : key
+  ),
+  ...Object.keys(builtInPaletteSystem.trueBlue)
+];
+
+for (const [id, label] of paletteIds) {
+  const nativeColumn = dom('div', { class: 'column' });
+  const previewColumn = dom('div', { class: 'column' });
+
+  nativeColumn.append(
+    dom('div', { class: 'swatch header' }, null, [`${label} (real)`]),
+    ...paletteKeys.map((key) =>
+      dom('div', { class: 'swatch', style: `background: var(--${key}, repeating-linear-gradient(45deg, rgb(255 0 0 / 0.5), rgb(255 0 0 / 0.5) 2px, transparent 4px, transparent 20px))` }, null, [key])
+    )
+  );
+  previewColumn.append(
+    dom('div', { class: 'swatch header' }, null, [label]),
+    ...paletteKeys.map((key) =>
+      dom('div', { class: 'swatch', style: `background: var(--${key}, repeating-linear-gradient(45deg, rgb(255 0 0 / 0.5), rgb(255 0 0 / 0.5) 2px, transparent 4px, transparent 20px))` }, null, [key])
+    )
+  );
+
+  let currentPaletteData = builtInPalettes[id];
+  if (currentPaletteData.accent && !currentPaletteData['deprecated-accent']) {
+    currentPaletteData = {
+      ...currentPaletteData,
+      'deprecated-accent': currentPaletteData.accent
+    };
+    delete currentPaletteData.accent;
+  }
+  const currentPaletteSystemData = builtInPaletteSystem[id];
+
+  Object.entries({ ...currentPaletteData, ...currentPaletteSystemData }).forEach(
+    ([property, value]) =>
+      nativeColumn.style.setProperty(
+        `--${property}`,
+        !value || value.startsWith('rgb') ? value : `rgba(${value})`
+      )
+  );
+
+  Object.entries({ ...currentPaletteData, ...getSemanticTokens(currentPaletteData) }).forEach(
+    ([property, value]) =>
+      previewColumn.style.setProperty(
+        `--${property}`,
+        !value || value.startsWith('rgb') ? value : `rgba(${value})`
+      )
+  );
+
+  containerElement.append(dom('div', { class: 'columns' }, null, [nativeColumn, previewColumn]));
+}

--- a/src/get_custom_tokens.js
+++ b/src/get_custom_tokens.js
@@ -1,4 +1,57 @@
 import Color from './lib/color.min.js';
+
+export const getCustomTokens = (colors) => {
+  const result = {};
+
+  [
+    'navy',
+    'blue',
+    'purple',
+    'pink',
+    'red',
+    'orange',
+    'yellow',
+    'green',
+    'black',
+    'white',
+    'white-on-dark',
+    'secondary-accent',
+    'deprecated-accent'
+  ].forEach((colorNameKebab) => {
+    const camelCase = (kebabCase) => kebabCase.replace(/-./g, (match) => match[1].toUpperCase());
+
+    const key = camelCase(`color-${(colorNameKebab)}`);
+    const color = `rgba(${colors[colorNameKebab]}, 1)`;
+
+    result[key] = color;
+
+    const colorJsColor = new Color(color);
+    const toWhite = colorJsColor.range('white', { space: 'srgb' });
+    const toBlack = colorJsColor.range('black', { space: 'srgb' });
+
+    const toStringFormat = { format: 'rgba_number', precision: 4 };
+
+    [3, 5, 10, 15, 20, 30, 40, 50, 60, 70, 80, 85, 90, 95, 100].forEach((num) => {
+      if (colorNameKebab === 'navy') {
+        result[`${key}${num}`] = toWhite((100 - num) / 100).toString(toStringFormat);
+      } else {
+        result[`${key}${num}`] = (
+          num > 50 ? toBlack((num * 2 - 100) / 100) : toWhite((100 - num * 2) / 100)
+        ).toString(toStringFormat);
+      }
+    });
+
+    [3, 5, 10, 15, 20, 30, 40, 50, 60, 70, 80, 85, 90, 95, 100].forEach((num) => {
+      result[`${key}Tint${num}`] = `rgba(${colors[colorNameKebab]}, ${num / 100})`;
+    });
+  });
+
+  result.colorTransparent = 'rgba(255, 255, 255, 0)';
+
+  return result;
+};
+
+/*
 import * as colors from './color_tokens.js';
 
 const getDelta = (baseColorRgb, targetColorRgb) => {
@@ -598,3 +651,4 @@ export const getCustomTokens = ({
     colorRainbow10: colorPurple
   };
 };
+*/

--- a/src/get_custom_tokens.js
+++ b/src/get_custom_tokens.js
@@ -18,6 +18,8 @@ export const getCustomTokens = (colors) => {
     'secondary-accent',
     'deprecated-accent'
   ].forEach((colorNameKebab) => {
+    if (!colors[colorNameKebab]) return;
+
     const camelCase = (kebabCase) => kebabCase.replace(/-./g, (match) => match[1].toUpperCase());
 
     const key = camelCase(`color-${(colorNameKebab)}`);

--- a/src/get_custom_tokens.js
+++ b/src/get_custom_tokens.js
@@ -1,26 +1,30 @@
 import Color from './lib/color.min.js';
 
+const camelCase = (kebabCase) => kebabCase.replace(/-./g, (match) => match[1].toUpperCase());
+
+const rootColorKeys = [
+  'black',
+  'white',
+  'white-on-dark',
+  'navy',
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'blue',
+  'purple',
+  'pink',
+  'deprecated-accent',
+  'secondary-accent'
+];
+
+const increments = [3, 5, 10, 15, 20, 30, 40, 50, 60, 70, 80, 85, 90, 95, 100];
+
 export const getCustomTokens = (colors) => {
   const result = {};
 
-  [
-    'navy',
-    'blue',
-    'purple',
-    'pink',
-    'red',
-    'orange',
-    'yellow',
-    'green',
-    'black',
-    'white',
-    'white-on-dark',
-    'secondary-accent',
-    'deprecated-accent'
-  ].forEach((colorNameKebab) => {
+  rootColorKeys.forEach((colorNameKebab) => {
     if (!colors[colorNameKebab]) return;
-
-    const camelCase = (kebabCase) => kebabCase.replace(/-./g, (match) => match[1].toUpperCase());
 
     const key = camelCase(`color-${(colorNameKebab)}`);
     const color = `rgba(${colors[colorNameKebab]}, 1)`;
@@ -30,8 +34,6 @@ export const getCustomTokens = (colors) => {
     const toWhite = new Color(color).range('white', { space: 'srgb' });
     const toBlack = new Color(color).range('black', { space: 'srgb' });
     const format = { format: 'rgba_number', precision: 4 };
-
-    const increments = [3, 5, 10, 15, 20, 30, 40, 50, 60, 70, 80, 85, 90, 95, 100];
 
     if (colorNameKebab === 'navy') {
       increments.forEach((num) => {

--- a/src/get_custom_tokens.js
+++ b/src/get_custom_tokens.js
@@ -25,23 +25,27 @@ export const getCustomTokens = (colors) => {
 
     result[key] = color;
 
-    const colorJsColor = new Color(color);
-    const toWhite = colorJsColor.range('white', { space: 'srgb' });
-    const toBlack = colorJsColor.range('black', { space: 'srgb' });
+    const toWhite = new Color(color).range('white', { space: 'srgb' });
+    const toBlack = new Color(color).range('black', { space: 'srgb' });
+    const format = { format: 'rgba_number', precision: 4 };
 
-    const toStringFormat = { format: 'rgba_number', precision: 4 };
+    const increments = [3, 5, 10, 15, 20, 30, 40, 50, 60, 70, 80, 85, 90, 95, 100];
 
-    [3, 5, 10, 15, 20, 30, 40, 50, 60, 70, 80, 85, 90, 95, 100].forEach((num) => {
-      if (colorNameKebab === 'navy') {
-        result[`${key}${num}`] = toWhite((100 - num) / 100).toString(toStringFormat);
-      } else {
-        result[`${key}${num}`] = (
-          num > 50 ? toBlack((num * 2 - 100) / 100) : toWhite((100 - num * 2) / 100)
-        ).toString(toStringFormat);
-      }
-    });
+    if (colorNameKebab === 'navy') {
+      increments.forEach((num) => {
+        result[`${key}${num}`] = toWhite((100 - num) / 100).toString(format);
+      });
+    } else {
+      increments.forEach((num) => {
+        if (num > 50) {
+          result[`${key}${num}`] = toBlack((num * 2 - 100) / 100).toString(format);
+        } else {
+          result[`${key}${num}`] = toWhite((100 - num * 2) / 100).toString(format);
+        }
+      });
+    }
 
-    [3, 5, 10, 15, 20, 30, 40, 50, 60, 70, 80, 85, 90, 95, 100].forEach((num) => {
+    increments.forEach((num) => {
       result[`${key}Tint${num}`] = `rgba(${colors[colorNameKebab]}, ${num / 100})`;
     });
   });

--- a/src/get_semantic_tokens.js
+++ b/src/get_semantic_tokens.js
@@ -1,4 +1,4 @@
-import { getCustomTokens } from './get_custom_tokens';
+import { getCustomTokens } from './get_custom_tokens.js';
 
 export const getSemanticTokens = (colors) => {
   const customTokens = getCustomTokens(colors);

--- a/src/get_semantic_tokens.js
+++ b/src/get_semantic_tokens.js
@@ -2,6 +2,7 @@ import { getCustomTokens } from './get_custom_tokens.js';
 
 export const getSemanticTokens = (colors) => {
   const customTokens = getCustomTokens(colors);
+  const staticTokens = getCustomTokens({ black: '0, 0, 0', white: '255, 255, 255' });
 
   return {
     chrome: customTokens.colorNavy,
@@ -35,11 +36,24 @@ export const getSemanticTokens = (colors) => {
     'content-fg-tertiary': customTokens.colorNavy40,
 
     'color-panel-border': customTokens.colorTransparent,
+    'color-tint': staticTokens.colorBlackTint10,
+    'color-tint-strong': staticTokens.colorBlackTint15,
+    'color-tint-heavy': staticTokens.colorBlackTint20,
+    'color-fg': staticTokens.colorBlack,
+    'color-fg-secondary': staticTokens.colorBlackTint80,
+    'color-fg-tertiary': staticTokens.colorBlackTint60,
+    'color-fg-light': staticTokens.colorWhite,
+    'color-fg-light-secondary': staticTokens.colorWhiteTint80,
+    'color-fg-light-tertiary': staticTokens.colorWhiteTint60,
 
+    'image-bg': staticTokens.colorBlack,
     'image-panel-border': customTokens.colorWhiteTint10,
-    'image-tint': customTokens.colorBlackTint40,
-    'image-tint-strong': customTokens.colorBlackTint50,
-    'image-tint-heavy': customTokens.colorBlackTint60,
+    'image-tint': staticTokens.colorBlackTint40,
+    'image-tint-strong': staticTokens.colorBlackTint50,
+    'image-tint-heavy': staticTokens.colorBlackTint60,
+    'image-fg': staticTokens.colorWhite,
+    'image-fg-secondary': staticTokens.colorWhiteTint80,
+    'image-fg-tertiary': staticTokens.colorWhiteTint60,
 
     'side-menu': customTokens.colorNavy,
     'side-menu-shadow': customTokens.colorWhiteTint10,
@@ -54,7 +68,8 @@ export const getSemanticTokens = (colors) => {
     'overlay-tint-heavy': customTokens.colorNavyTint80,
     'unread-tint': customTokens.colorBlueTint10,
     'unread-tint-hover': customTokens.colorBlueTint20,
-    'badge-text': customTokens.colorBlack,
+    'badge-text': staticTokens.colorBlack,
+    'badge-icon': staticTokens.colorWhite,
 
     'chrome-ui': customTokens.colorBlue,
     'chrome-ui-hover': customTokens.colorBlue40,
@@ -63,6 +78,7 @@ export const getSemanticTokens = (colors) => {
     'chrome-ui-fg': customTokens.colorBlack,
     'chrome-ui-fg-secondary': customTokens.colorBlackTint80,
     'chrome-ui-fg-tertiary': customTokens.colorBlackTint60,
+    'chrome-ui-toggle': staticTokens.colorWhite,
     'chrome-danger': customTokens.colorRed30,
     'chrome-success': customTokens.colorGreen30,
     'chrome-education': customTokens.colorPurple30,
@@ -81,6 +97,7 @@ export const getSemanticTokens = (colors) => {
     'content-ui-fg': customTokens.colorWhite,
     'content-ui-fg-secondary': customTokens.colorNavy40,
     'content-ui-fg-tertiary': customTokens.colorNavy60,
+    'content-ui-toggle': staticTokens.colorWhite,
     'content-danger': customTokens.colorRed70,
     'content-success': customTokens.colorGreen70,
     'content-education': customTokens.colorPurple70,
@@ -92,11 +109,23 @@ export const getSemanticTokens = (colors) => {
     'content-yellow': customTokens.colorYellow70,
     'content-green': customTokens.colorGreen70,
 
+    'color-ui': staticTokens.colorBlack,
+    'color-ui-hover': staticTokens.colorBlackTint90,
+    'color-ui-pressed': staticTokens.colorBlackTint80,
+    'color-ui-focus': staticTokens.colorBlack,
+    'color-ui-fg': staticTokens.colorWhite,
     'color-ui-fg-secondary': customTokens.colorGray40,
     'color-ui-fg-tertiary': customTokens.colorGray60,
+    'color-ui-toggle': staticTokens.colorWhite,
 
+    'image-ui': staticTokens.colorWhite,
+    'image-ui-hover': staticTokens.colorWhiteTint90,
+    'image-ui-pressed': staticTokens.colorWhiteTint80,
+    'image-ui-accent': staticTokens.colorWhite,
+    'image-ui-fg': staticTokens.colorBlack,
     'image-ui-fg-secondary': customTokens.colorNavy60,
     'image-ui-fg-tertiary': customTokens.colorNavy40,
+    'image-ui-toggle': staticTokens.colorWhite,
 
     'danger-hover': customTokens.colorRed60,
     'danger-pressed': customTokens.colorRed70,


### PR DESCRIPTION
The getSemanticTokens function is missing some tokens that are the same on every current palette. This generates them from white and black (not the variables named "white" and "black," the actual colors) (man, the terminology in this problem space is a massive pain, huh).

I guess `getCustomTokens` should probably be renamed if we do this.

_Stacked PR on #248; expect rebasing of this branch_