### PR TITLE
fix: Use browser.storage.local.onChanged.addListener

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -63,11 +63,7 @@ const applyFontSize = async function () {
   document.documentElement.style.setProperty('--base-font-size', fontSize);
 };
 
-const onStorageChanged = async function (changes, areaName) {
-  if (areaName !== 'local') {
-    return;
-  }
-
+const onStorageChanged = async function (changes) {
   const { currentPalette, fontFamily, customFontFamily, fontSize } = changes;
 
   if (currentPalette || Object.keys(changes).some(key => key.startsWith('palette:'))) {
@@ -81,4 +77,4 @@ const onStorageChanged = async function (changes, areaName) {
 applyCurrentPalette();
 applyFontFamily();
 applyFontSize();
-browser.storage.onChanged.addListener(onStorageChanged);
+browser.storage.local.onChanged.addListener(onStorageChanged);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As of Firefox 101, as per https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/onChanged, we should be able to use `browser.storage.local.onChanged.addListener` rather than using `browser.storage.onChanged.addListener` and checking if the second callback parameter is `'local'`.

See https://github.com/AprilSylph/XKit-Rewritten/pull/1755; this _may_ be a functionality fix in Safari (I am legitimately not sure; supposedly the bug was fixed in Safari 18.4. It's hard to tell because extension functionality seems to just explode randomly at any given time on Safari.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that changing extension preferences works in desktop Chromium.
- Confirm that changing extension preferences works in desktop Firefox.
- Confirm that changing extension preferences works in desktop Safari. (This is now reasonably easy, as Safari ≥18.4 allows loading unpacked extensions.)
- Confirm that changing extension preferences works in Firefox for Android.
