### PR TITLE
fix: override post-related design tokens

### DIFF
--- a/src/static.css
+++ b/src/static.css
@@ -8,3 +8,13 @@
   --font-family: unset !important;
   --font-family-modern: unset !important;
 }
+
+/* Port old CSS variables to new design system tokens */
+:root[style*="--white"]:not([style*="--content-panel"]) { --content-panel: rgb(var(--white)); }
+:root[style*="--black"]:not([style*="--content-tint"]) { --content-tint: rgba(var(--black), 0.07); }
+:root[style*="--black"]:not([style*="--content-tint-strong"]) { --content-tint-strong: rgba(var(--black), 0.13); }
+:root[style*="--black"]:not([style*="--content-tint-heavy"]) { --content-tint-heavy: rgba(var(--black), 0.25); }
+:root[style*="--black"]:not([style*="--content-fg"]) { --content-fg: rgb(var(--black)); }
+:root[style*="--black"]:not([style*="--content-fg-secondary"]) { --content-fg-secondary: rgba(var(--black), 0.65); }
+:root[style*="--black"]:not([style*="--content-fg-tertiary"]) { --content-fg-tertiary: rgba(var(--black), 0.4); }
+:root[style*="--white"]:not([style*="--modal"]) { --modal: rgb(var(--white)); }


### PR DESCRIPTION
### Description

- fixes #244
- fixes #243

New approach to this mess... just do a little bit at a time as issues are filed. Don't let perfect be the enemy of good.

There aren't too many colours used in posts, so it's actually only a small amount of work needed to rescue custom palettes from their current "unusable" status.

### Screenshots

Before | After
-|-
<img width="3600" height="2400" alt="Screen Shot 2025-09-10 at 12 47 46" src="https://github.com/user-attachments/assets/e9df04c7-a422-4f0f-bfc4-5763150d660c" /> | <img width="3600" height="2400" alt="Screen Shot 2025-09-10 at 12 47 59" src="https://github.com/user-attachments/assets/a4acdf86-c07e-46a0-af75-3ef86483d845" />

### Testing steps

1. Go to https://www.tumblr.com/settings/dashboard and set the palette to True Blue
2. Load the modified addon
3. Import this custom palette version of Dark Mode: [Palettes Backup @ 2025-09-10.json](https://github.com/user-attachments/files/22254092/Palettes.Backup.%40.2025-09-10.json)
4. Enable the custom palette
    - [ ] **Expected result**: Posts are the correct colour (`#222222`)
    - [ ] **Expected result**: Post text is the correct colour (`#ffffff`)
    - [ ] **Expected result**: No elements within normal blog posts stand out as being a wildly incorrect colour
    - [ ] **Expected result**: No elements within community posts stand out as being a wildly incorrect colour
