### PR TITLE
fix: override accent-related design tokens

### DIFF
--- a/src/static.css
+++ b/src/static.css
@@ -10,6 +10,8 @@
 }
 
 /* Port old CSS variables to new design system tokens */
+:root[style*="--deprecated-accent"]:not([style*="--accent"]) { --accent: rgb(var(--deprecated-accent)); }
+:root[style*="--navy"]:not([style*="--accent-fg"]) { --accent-fg: rgb(var(--navy)); }
 :root[style*="--white"]:not([style*="--content-panel"]) { --content-panel: rgb(var(--white)); }
 :root[style*="--black"]:not([style*="--content-tint"]) { --content-tint: rgba(var(--black), 0.07); }
 :root[style*="--black"]:not([style*="--content-tint-strong"]) { --content-tint-strong: rgba(var(--black), 0.13); }
@@ -18,3 +20,5 @@
 :root[style*="--black"]:not([style*="--content-fg-secondary"]) { --content-fg-secondary: rgba(var(--black), 0.65); }
 :root[style*="--black"]:not([style*="--content-fg-tertiary"]) { --content-fg-tertiary: rgba(var(--black), 0.4); }
 :root[style*="--white"]:not([style*="--modal"]) { --modal: rgb(var(--white)); }
+:root[style*="--deprecated-accent"]:not([style*="--chrome-ui"]) { --chrome-ui: rgb(var(--deprecated-accent)); }
+:root[style*="--navy"]:not([style*="--chrome-ui-fg"]) { --chrome-ui-fg: rgb(var(--navy)); }


### PR DESCRIPTION
- [ ] **TODO**: Fix `--chrome-ui-hover`

---

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
- fixes #192 
- relates to #191 

Overrides `--accent`, `--accent-fg`, `--chrome-ui`, and `--chrome-ui-fg` when a custom palette is applied.

Of note here is my choice to use `--navy` for `--accent-fg`, which in the new system actually uses pure black on True Blue. I've done this because, in the legacy palette system, there is no guarantee that black contrasts with accent—accent is only guaranteed to contrast against navy. Even the Prima dashboard uses navy-on-accent for notification badges, and that thing doesn't even have different palettes!

### Screenshots

Custom palette version of Dark Mode applied on top of Cement:

Before | After
-|-
<img width="3840" height="2400" alt="Screen Shot 2025-09-16 at 14 25 10" src="https://github.com/user-attachments/assets/40644837-d080-4f5a-923a-5dc7b453e4b6" /> | <img width="3840" height="2400" alt="Screen Shot 2025-09-16 at 14 25 27" src="https://github.com/user-attachments/assets/8d5466a6-e21b-4d16-80da-3a6b423ce6a3" />

Custom palette version of Cement applied on top of Dark Mode:

Before | After
-|-
<img width="3840" height="2400" alt="Screen Shot 2025-09-16 at 14 28 17" src="https://github.com/user-attachments/assets/d1ad71bb-f2b7-4daf-8360-eb1dec068a31" /> | <img width="3840" height="2400" alt="Screen Shot 2025-09-16 at 14 28 56" src="https://github.com/user-attachments/assets/f8f711cf-0b3d-494f-a047-b19ceb630be3" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?
  If any custom palettes are needed for testing, please upload them here.
-->
TBD
