### PR TITLE
 fix(custom palettes): add remaining accent-related overrides

### DIFF
--- a/src/static.css
+++ b/src/static.css
@@ -16,7 +16,9 @@
 :root:not([style*="--accent"])[style*="--deprecated-accent"] {
   --accent: rgb(var(--deprecated-accent));
   --accent-fg: rgb(var(--navy));
+  --accent-fg-light: rgb(var(--white-on-dark));
   --accent-hover: color-mix(in srgb, rgb(var(--deprecated-accent)), rgb(var(--white-on-dark)) 20%);
+  --accent-pressed: color-mix(in srgb, rgb(var(--deprecated-accent)), rgb(var(--white-on-dark)) 40%);
   --accent-tint: rgba(var(--deprecated-accent), 0.1);
   --accent-tint-strong: rgba(var(--deprecated-accent), 0.2);
   --accent-tint-heavy: rgba(var(--deprecated-accent), 0.3);

--- a/src/static.css
+++ b/src/static.css
@@ -10,34 +10,20 @@
 }
 
 /* Port old CSS variables to new design system tokens */
-:root:not([style*="--accent"])[style*="--deprecated-accent"] {
-  --accent: rgb(var(--deprecated-accent));
-}
-:root:not([style*="--accent-fg"])[style*="--navy"] {
-  --accent-fg: rgb(var(--navy));
-}
 :root:not([style*="--chrome"])[style*="--navy"] {
   --chrome: rgb(var(--navy));
 }
+:root:not([style*="--accent"])[style*="--deprecated-accent"] {
+  --accent: rgb(var(--deprecated-accent));
+  --accent-fg: rgb(var(--navy));
+}
 :root:not([style*="--content-panel"])[style*="--white"] {
   --content-panel: rgb(var(--white));
-}
-:root:not([style*="--content-tint"])[style*="--black"] {
   --content-tint: rgba(var(--black), 0.07);
-}
-:root:not([style*="--content-tint-strong"])[style*="--black"] {
   --content-tint-strong: rgba(var(--black), 0.13);
-}
-:root:not([style*="--content-tint-heavy"])[style*="--black"] {
   --content-tint-heavy: rgba(var(--black), 0.25);
-}
-:root:not([style*="--content-fg"])[style*="--black"] {
   --content-fg: rgb(var(--black));
-}
-:root:not([style*="--content-fg-secondary"])[style*="--black"] {
   --content-fg-secondary: rgba(var(--black), 0.65);
-}
-:root:not([style*="--content-fg-tertiary"])[style*="--black"] {
   --content-fg-tertiary: rgba(var(--black), 0.4);
 }
 :root:not([style*="--modal"])[style*="--white"] {
@@ -45,16 +31,8 @@
 }
 :root:not([style*="--chrome-ui"])[style*="--deprecated-accent"] {
   --chrome-ui: rgb(var(--deprecated-accent));
-}
-:root:not([style*="--chrome-ui-hover"])[style*="--deprecated-accent"][style*="--white-on-dark"] {
   --chrome-ui-hover: color-mix(in srgb, rgb(var(--deprecated-accent)), rgb(var(--white-on-dark)) 20%);
-}
-:root:not([style*="--chrome-ui-pressed"])[style*="--deprecated-accent"][style*="--navy"] {
   --chrome-ui-pressed: color-mix(in srgb, rgb(var(--deprecated-accent)), rgb(var(--navy)) 10%);
-}
-:root:not([style*="--chrome-ui-focus"])[style*="--deprecated-accent"] {
   --chrome-ui-focus: rgb(var(--deprecated-accent));
-}
-:root:not([style*="--chrome-ui-fg"])[style*="--navy"] {
   --chrome-ui-fg: rgb(var(--navy));
 }

--- a/src/static.css
+++ b/src/static.css
@@ -16,6 +16,10 @@
 :root:not([style*="--accent"])[style*="--deprecated-accent"] {
   --accent: rgb(var(--deprecated-accent));
   --accent-fg: rgb(var(--navy));
+  --accent-hover: color-mix(in srgb, rgb(var(--deprecated-accent)), rgb(var(--white-on-dark)) 20%);
+  --accent-tint: rgba(var(--deprecated-accent), 0.1);
+  --accent-tint-strong: rgba(var(--deprecated-accent), 0.2);
+  --accent-tint-heavy: rgba(var(--deprecated-accent), 0.3);
 }
 :root:not([style*="--content-panel"])[style*="--white"] {
   --content-panel: rgb(var(--white));


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
- fixes #191

Before | After
-|-
<img width="3840" height="2400" alt="Screen Shot 2025-10-03 at 15 40 46" src="https://github.com/user-attachments/assets/b0cef297-bd41-44c9-84bc-83974b2eeb67" /> | <img width="3840" height="2400" alt="Screen Shot 2025-10-03 at 15 41 04" src="https://github.com/user-attachments/assets/c4c4167a-9e48-4378-90a4-d5ec8dfa3ad5" />
"Dark Mode Legacy" applied on top of Cement. | The glow effect of the selected option is now visible.
<img width="3840" height="2400" alt="Screen Shot 2025-10-03 at 16 09 32" src="https://github.com/user-attachments/assets/94c3fd99-8e3f-433b-bf12-922694556d82" /> | <img width="3840" height="2400" alt="Screen Shot 2025-10-03 at 16 09 51" src="https://github.com/user-attachments/assets/5044d5ef-50f8-4c55-a1ac-ab261beaf78c" />
"Cement Legacy" applied on top of Dark Mode. | The glow effect of the selected option now matches the solid colour used for the option's outline and checked radio button.

The way Tumblr is using these semantic tokens is definitely going to break a few custom palettes.
But, this way they will be broken in a way that the user can work around, instead of being broken outright...

`--chrome-ui` needs to contrast against `--chrome`, but not necessarily against `--modal` (which is the same as `--content-panel` in every Tumblr-provided palette, as I understand it). That's pretty easy to map from the old system:
- `--chrome-ui` is the new "accent"
- `--chrome` is the new "navy"
- `--content-panel`/`--modal` is the new "white"

Meanwhile, `--accent` needs to contrast against both `--chrome` and `--modal`, since it is used both for notification badges and for highlighted options within dialogues. But also, `--accent` is the same colour as `--chrome-ui` in every Tumblr-provided palette. And since we're limited to the number of variables in the old system as a base, we run out of options for mapping very fast. We _have to_ map "accent" to `--accent`, or we break notification badges being the same colour as the new post button.

Something notable is that `--accent` does, in fact, contrast against `--content-panel`/`--modal` in every Tumblr-provided palette. So, while it's not a rule of the old system that "accent" has to contrast against "white", it is a reality now. So, pour one out for all the custom palettes which make those the same colour—it's just not possible anymore.

In an ideal world, we could petition to have notification badges changed to use `--chrome-ui` tokens, and then map custom palettes' "blue" to `--accent` instead, since "blue" and "white" _do_ have to contrast in the old system... But, this is not an ideal world.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?
  If any custom palettes are needed for testing, please upload them here.
-->
1. Load the modified addon
2. Import these custom palettes: [Palettes Backup @ 2025-10-03.json](https://github.com/user-attachments/files/22682882/Palettes.Backup.%40.2025-10-03.json)
3. In a community that you have joined but do not moderate, start the process of reporting a comment, and select a reason
    - [ ] **Expected result**: The "Dark Mode Legacy" custom palette overrides the background colour of the selected option, regardless of the base palette
    - [ ] **Expected result**: The "Cement Legacy" custom palette overrides the background colour of the selected option, regardless of the base palette
