### PR TITLE
chore: Improve update-palette-system-data.js dev script

### DIFF
--- a/dev/update-palette-system-data.js
+++ b/dev/update-palette-system-data.js
@@ -5,7 +5,6 @@ import fs from 'node:fs/promises';
 
 try {
   const browser = await launch({ browser: 'firefox', headless: false });
-  await new Promise(resolve => setTimeout(resolve, 5000));
   const page = await browser.newPage();
   await page.goto('https://www.tumblr.com/');
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

As noted in #259:

> 3. Run `node dev/update-palette-system-data.js`
    - [ ] **Expected result**: The script runs as usual, and updates `src/palette_system_data.json`
    (If your system is set to prefer a dark colour scheme, it will erroneously update the `darkMode` data with True Blue variables; otherwise, it will do nothing except remove the file's final newline. We obviously do not want to commit either of these.)

This fixes both the missing trailing newline and the issue where systems that prefer dark mode would have true blue data written in dark mode, because the dark mode data is in a media query.

Slightly better viewed with hidden whitespace changes.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?
  If any custom palettes are needed for testing, please upload them here.
-->

- On systems that default to dark mode: run `./dev/update-palette-system-data.js` and confirm that no changes are made to `src/palette_system_data.json`.
- On systems that default to dark mode: un-revert the test commit, run `./dev/update-palette-system-data.js`, quickly switch Firefox to dark mode, let the script finish, and confirm that no changes are made to `src/palette_system_data.json`.
