### PR TITLE
fix(custom palettes): add `--chrome-fg-*` and related mappings

### DIFF
--- a/src/static.css
+++ b/src/static.css
@@ -12,6 +12,7 @@
 /* Port old CSS variables to new design system tokens */
 :root:not([style*="--chrome"])[style*="--navy"] {
   --chrome: rgb(var(--navy));
+  --chrome-mobile: rgb(var(--navy));
   --chrome-panel: color-mix(in srgb, rgb(var(--navy)), rgb(var(--white-on-dark)) 7%);
   --chrome-panel-border: rgba(var(--white-on-dark), 0.07);
 }

--- a/src/static.css
+++ b/src/static.css
@@ -17,6 +17,9 @@
   --chrome-fg: rgb(var(--white-on-dark));
   --chrome-fg-secondary: rgba(var(--white-on-dark), 0.65);
   --chrome-fg-tertiary: rgba(var(--white-on-dark), 0.4);
+  --chrome-tint: rgba(var(--white-on-dark), 0.07);
+  --chrome-tint-strong: rgba(var(--white-on-dark), 0.13);
+  --chrome-tint-heavy: rgba(var(--white-on-dark), 0.25);
 }
 :root:not([style*="--accent"])[style*="--deprecated-accent"] {
   --accent: rgb(var(--deprecated-accent));

--- a/src/static.css
+++ b/src/static.css
@@ -13,6 +13,11 @@
 :root:not([style*="--chrome"])[style*="--navy"] {
   --chrome: rgb(var(--navy));
 }
+:root:not([style*="--chrome-fg"])[style*="--white-on-dark"] {
+  --chrome-fg: rgb(var(--white-on-dark));
+  --chrome-fg-secondary: rgba(var(--white-on-dark), 0.65);
+  --chrome-fg-tertiary: rgba(var(--white-on-dark), 0.4);
+}
 :root:not([style*="--accent"])[style*="--deprecated-accent"] {
   --accent: rgb(var(--deprecated-accent));
   --accent-fg: rgb(var(--navy));

--- a/src/static.css
+++ b/src/static.css
@@ -12,6 +12,8 @@
 /* Port old CSS variables to new design system tokens */
 :root:not([style*="--chrome"])[style*="--navy"] {
   --chrome: rgb(var(--navy));
+  --chrome-panel: color-mix(in srgb, rgb(var(--navy)), rgb(var(--white-on-dark)) 7%);
+  --chrome-panel-border: rgba(var(--white-on-dark), 0.07);
 }
 :root:not([style*="--chrome-fg"])[style*="--white-on-dark"] {
   --chrome-fg: rgb(var(--white-on-dark));


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
Fixes the "white on dark" custom palette colour not being applied to Tumblr.

(Pictured: Custom palette clone of Cybernetic applied on top of Pride.)

Before | After
-|-
<img width="3840" height="2400" alt="Screen Shot 2026-05-01 at 10 57 57" src="https://github.com/user-attachments/assets/80e68177-2ba3-4b67-88a9-6ca99494c227" /> | <img width="3840" height="2400" alt="Screen Shot 2026-05-01 at 10 58 10" src="https://github.com/user-attachments/assets/5d740b55-b575-463b-a0d5-cbd69b0a2012" />
<img width="3840" height="2400" alt="Screen Shot 2026-05-01 at 10 59 27" src="https://github.com/user-attachments/assets/4dfc2901-8127-4797-bda8-67435de36742" /> | <img width="3840" height="2400" alt="Screen Shot 2026-05-01 at 10 59 41" src="https://github.com/user-attachments/assets/e3ebdc4e-c359-4a24-9000-0a4d8703eb41" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?
  If any custom palettes are needed for testing, please upload them here.
-->
1. Load the modified addon
2. Create a custom palette with a very noticeable "white on dark" colour
3. Activate that palette, and click around Tumblr. Can you find any spots where it's not being applied, but should be?
