### PR TITLE
fix: Work around broken puppeteer click util in Firefox 151+

### DIFF
--- a/dev/update-palette-system-data.js
+++ b/dev/update-palette-system-data.js
@@ -15,7 +15,7 @@ try {
       const privacyAgreeButton = await frame.$('.cmp__dialog-footer button.cmp-components-button.white-space-normal.is-primary');
       privacyAgreeButton?.evaluate((element) => {
         // let evaluate function call return cleanly before iframe context is invalidated
-        requestAnimationFrame(() => element.click());
+        setTimeout(() => element.click(), 0);
       });
     })
   );

--- a/dev/update-palette-system-data.js
+++ b/dev/update-palette-system-data.js
@@ -13,7 +13,10 @@ try {
   await Promise.all(
     page.frames().map(async (frame) => {
       const privacyAgreeButton = await frame.$('.cmp__dialog-footer button.cmp-components-button.white-space-normal.is-primary');
-      privacyAgreeButton?.click();
+      privacyAgreeButton?.evaluate((element) => {
+        // let evaluate function call return cleanly before iframe context is invalidated
+        requestAnimationFrame(() => element.click());
+      });
     })
   );
   await page.waitForSelector(':root:not(:has(#cmp-app-container iframe))');


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Avoids the puppeteer click util, preventing a crash; see #311.

Interestingly, setTimeout and requestAnimationFrame work here, but queueMicrotask does not, for some reason.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?
  If any custom palettes are needed for testing, please upload them here.
-->

`dev/update-palette-system-data.js`