### PR TITLE
chore: Set `allowScripts` package value for npm 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "normalize.css": "^8.0.1",
     "webextension-polyfill": "^0.12.0"
   },
+  "allowScripts": {
+    "puppeteer": true,
+    "unrs-resolver": false
+  },
   "webExt": {
     "sourceDir": "src/",
     "build": {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

npm 12 has the breaking change that dependency postinstall scripts are blocked unless explicitly allowed. This project has two relevant dependencies: `unrs-resolver`'s seems unnecessary (see https://github.com/AprilSylph/XKit-Rewritten/pull/2315); puppeteer's is required (unless you want to instruct developers to run `npx puppeteer browsers install`, which also works).

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?
  If any custom palettes are needed for testing, please upload them here.
-->

To be totally honest, I didn't test the puppeteer installation part of this; presumably you would delete your node_modules and do `npx puppeteer browsers clear`, then `npm ci` and `dev/update-palette-system-data.js`. Or run the CI action on this branch.