### PR TITLE
Intercept Shift+P while overriding Tumblr palettes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,9 +4,18 @@ const setCssVariable = ([property, value]) => document.documentElement.style.set
 const removeCssVariable = ([property]) => document.documentElement.style.removeProperty(`--${property}`);
 
 let appliedPaletteEntries = [];
+let paletteIsOverridden = false;
+
+const interceptPaletteShortcut = function (event) {
+  if (!paletteIsOverridden || !event.shiftKey || event.key !== 'P') return;
+
+  event.preventDefault();
+  event.stopImmediatePropagation();
+};
 
 const applyCurrentPalette = async function () {
   const { currentPalette = '' } = await browser.storage.local.get('currentPalette');
+  paletteIsOverridden = Boolean(currentPalette);
 
   if (!currentPalette) {
     appliedPaletteEntries.forEach(removeCssVariable);
@@ -66,6 +75,7 @@ const applyFontSize = async function () {
 const onStorageChanged = async function (changes) {
   const { currentPalette, fontFamily, customFontFamily, fontSize } = changes;
 
+  if (currentPalette) paletteIsOverridden = Boolean(currentPalette.newValue);
   if (currentPalette || Object.keys(changes).some(key => key.startsWith('palette:'))) {
     applyCurrentPalette();
   }
@@ -77,4 +87,5 @@ const onStorageChanged = async function (changes) {
 applyCurrentPalette();
 applyFontFamily();
 applyFontSize();
+window.addEventListener('keydown', interceptPaletteShortcut, true);
 browser.storage.local.onChanged.addListener(onStorageChanged);

--- a/test/main-shortcut.test.js
+++ b/test/main-shortcut.test.js
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('intercepts Shift+P when a custom palette is selected', async () => {
+  const eventListeners = new Map();
+  let storageChangedListener;
+  const storage = {
+    currentPalette: 'palette:custom:1',
+    'palette:custom:1': { background: '#fff' }
+  };
+
+  globalThis.window = {
+    addEventListener (type, listener, options) {
+      eventListeners.set(type, { listener, options });
+    }
+  };
+  globalThis.document = {
+    createElement () {
+      return {};
+    },
+    documentElement: {
+      append () {},
+      style: {
+        removeProperty () {},
+        setProperty () {}
+      }
+    },
+    head: {
+      querySelectorAll () {
+        return [];
+      }
+    },
+    readyState: 'complete',
+    getElementById () {
+      return null;
+    }
+  };
+  globalThis.MutationObserver = class {
+    observe () {}
+  };
+  globalThis.fetch = async url => ({
+    json: async () => url.endsWith('/palette_system_data.json') ? {} : {}
+  });
+  globalThis.browser = {
+    runtime: {
+      getURL: path => new URL(`../src${path}`, import.meta.url).href
+    },
+    storage: {
+      local: {
+        async get (key) {
+          return { [key]: storage[key] };
+        },
+        onChanged: {
+          addListener (listener) {
+            storageChangedListener = listener;
+          }
+        }
+      }
+    }
+  };
+
+  await import('../src/main.js');
+  await new Promise(resolve => setImmediate(resolve));
+
+  const keydown = eventListeners.get('keydown');
+  assert.equal(typeof keydown?.listener, 'function', 'registers a keydown listener');
+  assert.equal(keydown.options, true, 'registers the listener during capture');
+
+  let prevented = false;
+  let propagationStopped = false;
+  keydown.listener({
+    key: 'P',
+    shiftKey: true,
+    preventDefault () {
+      prevented = true;
+    },
+    stopImmediatePropagation () {
+      propagationStopped = true;
+    }
+  });
+
+  assert.equal(prevented, true, 'prevents Tumblr from handling the shortcut');
+  assert.equal(propagationStopped, true, 'stops Tumblr keyboard listeners');
+
+  storage.currentPalette = '';
+  storageChangedListener({ currentPalette: { oldValue: 'palette:custom:1', newValue: '' } });
+  prevented = false;
+  propagationStopped = false;
+  keydown.listener({
+    key: 'P',
+    shiftKey: true,
+    preventDefault () {
+      prevented = true;
+    },
+    stopImmediatePropagation () {
+      propagationStopped = true;
+    }
+  });
+
+  assert.equal(prevented, false, 'leaves the shortcut enabled without an override');
+  assert.equal(propagationStopped, false, 'leaves Tumblr keyboard listeners enabled');
+});


### PR DESCRIPTION
## Summary
- intercept Tumblr’s Shift+P palette shortcut while an extension palette is active
- update interception state when the selected palette changes
- add a focused regression test covering enabled and disabled overrides

## Testing
- `OPENSSL_CONF=/dev/null node test/main-shortcut.test.js`
- `OPENSSL_CONF=/dev/null node --check src/main.js`
- `OPENSSL_CONF=/dev/null node --check test/main-shortcut.test.js`

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1010:start -->
### Verification

[Northset proof-of-pass receipt M-1010](https://northset-oss.github.io/verification-pilot/receipts/M-1010/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1010:end -->
