### PR TITLE
chore: Rename old blue palettes

### DIFF
--- a/src/palettes.json
+++ b/src/palettes.json
@@ -17,9 +17,9 @@
   ],
   [
     "Palettes from Tumblr past", [
-      ["2013", "circa 2013"],
+      ["2013", "Old Blue, circa 2013"],
       ["decision2016", "Decision 2016"],
-      ["2016", "circa 2016"],
+      ["2016", "Old Blue, circa 2016"],
       ["cement2025", "Cement, circa 2025"]
     ]
   ]

--- a/src/palettes.json
+++ b/src/palettes.json
@@ -18,8 +18,8 @@
   [
     "Palettes from Tumblr past", [
       ["2013", "Old Blue, circa 2013"],
-      ["decision2016", "Decision 2016"],
       ["2016", "Old Blue, circa 2016"],
+      ["decision2016", "Decision 2016"],
       ["cement2025", "Cement, circa 2025"]
     ]
   ]


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

This applies clearer naming to the included old blue palettes. See https://github.com/AprilSylph/Palettes-for-Tumblr/pull/317#issuecomment-5143535825.

Also a stacked PR on that one mostly because I needed an excuse to see what the creation UI looks like.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

<img width="259" src="https://github.com/user-attachments/assets/e6e4af8d-5171-407d-8898-0f6f00bb3be5" />


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?
  If any custom palettes are needed for testing, please upload them here.
-->

This is more of a visual thing; do you think the options look weird as laid out here? Does it make more sense to swap Old Blue 2016 and Decision 2016?